### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Build stage
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+# Install git for fetching dependencies
+RUN apk add --no-cache git
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY miniflux-luma.go ./
+
+# Build the application
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o miniflux-luma .
+
+# Final stage
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+# Copy the binary from builder
+COPY --from=builder /app/miniflux-luma .
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Expose port
+EXPOSE 8080
+
+# Default command
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["-listen-addr", "0.0.0.0:8080", "-endpoint", "http://miniflux:8080"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+if [ -n "$MINIFLUX_API_TOKEN" ]; then
+  echo "$MINIFLUX_API_TOKEN" > /tmp/api_token
+  exec ./miniflux-luma -api-token-file /tmp/api_token "$@"
+else
+  echo "Error: MINIFLUX_API_TOKEN environment variable not set"
+  echo "Please add MINIFLUX_API_TOKEN to your .env file"
+  exit 1
+fi


### PR DESCRIPTION
Adds Dockerfile and entrypoint script for containerized deployment.

## Changes
- `Dockerfile`: Multi-stage Go build
- `entrypoint.sh`: Handles API token from environment variable

## Usage
```bash
docker build -t miniflux-luma .
docker run -e MINIFLUX_API_TOKEN=your_token miniflux-luma
```